### PR TITLE
GPIO interrupt handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 name = "photogate-node"
 version = "0.1.0"
 dependencies = [
+ "critical-section",
  "defmt",
  "drivers",
  "embassy-executor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "bitfield"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c821a6e124197eb56d907ccc2188eab1038fb919c914f47976e64dd8dbc855d1"
+checksum = "d5acf59e2452f0c4b968b15ce4b9468f57b45f7733b919d68b19fcc39264bfb8"
 
 [[package]]
 name = "bitflags"
@@ -107,9 +98,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
 
 [[package]]
 name = "byteorder"
@@ -154,7 +145,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -168,19 +159,6 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
-
-[[package]]
-name = "core-isa-parser"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ec98e54b735872e54b2335c2e5a5c7fa7d9c3bfd45500f75280f84089a0083"
-dependencies = [
- "anyhow",
- "enum-as-inner",
- "regex",
- "strum 0.24.1",
- "strum_macros 0.24.3",
-]
 
 [[package]]
 name = "critical-section"
@@ -209,7 +187,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -220,7 +198,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -243,7 +221,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -263,7 +241,7 @@ checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -307,7 +285,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -489,35 +467,35 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "enumset"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226c0da7462c13fb57e5cc9e0dc8f0635e7d27f276a3a7fd30054647f669007d"
+checksum = "d07a4b049558765cef5f0c1a273c3fc57084d768b44d2f98127aef4cceb17293"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
+checksum = "59c3b24c345d8c314966bdc1832f6c2635bfcce8e7cf363bd115987bba2ee242"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -538,13 +516,13 @@ dependencies = [
 
 [[package]]
 name = "esp-backtrace"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a34817530dceba397172d6a9fb660b684a73a3a591fbe7fb0da27bed796f270"
+checksum = "236ebd8a874b490b4c3bb3fbfc49f10732729012bf9d639b3a17570d2ba79a07"
 dependencies = [
  "defmt",
- "esp-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "esp-println 0.10.0",
+ "esp-build",
+ "esp-println",
 ]
 
 [[package]]
@@ -554,24 +532,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94a4b8d74e7cc7baabcca5b2277b41877e039ad9cd49959d48ef94dac7eab4b"
 dependencies = [
  "quote",
- "syn 2.0.75",
- "termcolor",
-]
-
-[[package]]
-name = "esp-build"
-version = "0.1.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
-dependencies = [
- "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
  "termcolor",
 ]
 
 [[package]]
 name = "esp-hal"
-version = "0.19.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f5393b8f7e7f055455d9f86706ddb675f943c12f12a7b80b8a79c3a94233ff"
 dependencies = [
  "basic-toml",
  "bitfield",
@@ -593,7 +562,7 @@ dependencies = [
  "embedded-io",
  "embedded-io-async",
  "enumset",
- "esp-build 0.1.0 (git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f)",
+ "esp-build",
  "esp-hal-procmacros",
  "esp-metadata",
  "esp-riscv-rt",
@@ -611,15 +580,16 @@ dependencies = [
  "rand_core",
  "riscv",
  "serde",
- "strum 0.26.3",
+ "strum",
  "void",
  "xtensa-lx-rt",
 ]
 
 [[package]]
 name = "esp-hal-embassy"
-version = "0.2.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e47f06e0d7ddf411c3a582ec8fdc4fbc91713aa14bad736618677df0ffb606"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -627,7 +597,7 @@ dependencies = [
  "document-features",
  "embassy-executor",
  "embassy-time-driver",
- "esp-build 0.1.0 (git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f)",
+ "esp-build",
  "esp-hal",
  "esp-hal-procmacros",
  "esp-metadata",
@@ -637,8 +607,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.12.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eac531546027909a355fc9c2449f22c839955fa4b7f1976b64ddd04b2f22f83"
 dependencies = [
  "darling",
  "document-features",
@@ -647,45 +618,40 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "esp-metadata"
-version = "0.2.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b471bc61fa817ca4ae41a31d5d453258328b31e5ad82db72b473621d36cc4cb6"
 dependencies = [
  "anyhow",
  "basic-toml",
  "clap",
  "lazy_static",
  "serde",
- "strum 0.26.3",
+ "strum",
 ]
 
 [[package]]
 name = "esp-println"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98f0f58453dd2ce08d99228fc8757fad39d05dfd26643665d1093b8844f42cc"
+checksum = "0d9dd4fc40306450e432cdf104ab00c8f6bd5c4f6c77b76c5fc3024c0e2a535d"
 dependencies = [
  "critical-section",
  "defmt",
-]
-
-[[package]]
-name = "esp-println"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd4fa834980ba64aad00a5c2c1a630020af984eadef65a125cb99085f6f54c"
-dependencies = [
- "esp-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "esp-build",
+ "portable-atomic",
 ]
 
 [[package]]
 name = "esp-riscv-rt"
 version = "0.9.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc32298ed7c263b06c8b031704d8517cc62c819f2a9d5c261d0cb119634d6e9"
 dependencies = [
  "document-features",
  "riscv",
@@ -694,8 +660,9 @@ dependencies = [
 
 [[package]]
 name = "esp32"
-version = "0.32.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85287b57fae3e318b62fd860787b1ac85a5e7bf91ad43eb66837c5e567218009"
 dependencies = [
  "critical-section",
  "defmt",
@@ -705,8 +672,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c2"
-version = "0.21.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9216c7ca4aefe4723d38a765e27801c4e92dec792870403466fc9adb438056"
 dependencies = [
  "critical-section",
  "defmt",
@@ -715,8 +683,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c3"
-version = "0.24.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3922cd13da83d070892c47e66f005856c62510952198c3008bc4f3b79f3e9623"
 dependencies = [
  "critical-section",
  "defmt",
@@ -725,8 +694,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c6"
-version = "0.15.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c05e230022cf5a8d10e9bcdc4878c0886a3a5701a96d6763cb42562e42ecd7"
 dependencies = [
  "critical-section",
  "defmt",
@@ -735,8 +705,9 @@ dependencies = [
 
 [[package]]
 name = "esp32h2"
-version = "0.11.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b05edd3bb766f66180b49c53b3503cf41b72936912a9552462a6a233ccdcac4"
 dependencies = [
  "critical-section",
  "defmt",
@@ -745,8 +716,9 @@ dependencies = [
 
 [[package]]
 name = "esp32s2"
-version = "0.23.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc0ce1947afdcc4cb74dc8955e1575fcfa38931e0282ed171811dde0afc0fc6"
 dependencies = [
  "critical-section",
  "defmt",
@@ -756,8 +728,9 @@ dependencies = [
 
 [[package]]
 name = "esp32s3"
-version = "0.27.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae51703c44196b924910bd8ea7285e5a234d1a5aebcd0b60a997cd5081eb002"
 dependencies = [
  "critical-section",
  "defmt",
@@ -908,9 +881,9 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "minijinja"
-version = "1.0.21"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e877d961d4f96ce13615862322df7c0b6d169d40cab71a7ef3f9b9e594451e"
+checksum = "6d7d3e3a3eece1fa4618237ad41e1de855ced47eab705cec1c9a920e1d1c5aad"
 dependencies = [
  "serde",
 ]
@@ -1019,7 +992,7 @@ dependencies = [
  "esp-backtrace",
  "esp-hal",
  "esp-hal-embassy",
- "esp-println 0.9.1",
+ "esp-println",
 ]
 
 [[package]]
@@ -1036,15 +1009,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
 ]
@@ -1084,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1102,35 +1075,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "regex"
-version = "1.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "riscv"
@@ -1167,22 +1111,31 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1217,30 +1170,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
-name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1253,7 +1187,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1269,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1304,22 +1238,39 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -1447,9 +1398,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -1467,25 +1418,31 @@ dependencies = [
 
 [[package]]
 name = "xtensa-lx-rt"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904102108b780c9a5e3275c5f3c63dc348ec43ae5da5237868515498b447d51a"
+checksum = "b657da7a82a76b695b12d9188be2d8437854157b20d543e2dcac5589bbc85f1c"
 dependencies = [
+ "anyhow",
  "bare-metal",
- "core-isa-parser",
+ "document-features",
+ "enum-as-inner",
  "minijinja",
  "r0",
+ "serde",
+ "strum",
+ "toml",
+ "xtensa-lx",
  "xtensa-lx-rt-proc-macros",
 ]
 
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082cdede098bbec9af15b0e74085e5f3d16f2923597de7aed7b8112003af2da7"
+checksum = "11277b1e4cbb7ffe44678c668518b249c843c81df249b8f096701757bc50d7ee"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +124,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
 name = "core-isa-parser"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "darling"
@@ -191,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec648daedd2143466eff4b3e8002024f9f6c1de4ab7666bb679688752624c925"
+checksum = "09ed0e24bdd4a5f4ff1b72ee4f264b1d23e179ea71a77d984b5fd24877a2bbe1"
 dependencies = [
  "critical-section",
  "defmt",
@@ -205,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor-macros"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad454accf80050e9cf7a51e994132ba0e56286b31f9317b68703897c328c59b5"
+checksum = "d4d4c0c34b32c2c653c9eecce1cefaf8539dd9a54e61deb5499254f01e2fcac2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -309,15 +404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d2e857f87ac832df68fa498d18ddc679175cf3d2e4aa893988e5601baf9438"
 dependencies = [
  "nb 1.1.0",
-]
-
-[[package]]
-name = "embedded-dma"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994f7e5b5cb23521c22304927195f236813053eb9c065dd2226a32ba64695446"
-dependencies = [
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -457,7 +543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a34817530dceba397172d6a9fb660b684a73a3a591fbe7fb0da27bed796f270"
 dependencies = [
  "defmt",
- "esp-build",
+ "esp-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "esp-println 0.10.0",
 ]
 
@@ -473,10 +559,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-build"
+version = "0.1.0"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
+dependencies = [
+ "quote",
+ "syn 2.0.75",
+ "termcolor",
+]
+
+[[package]]
 name = "esp-hal"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4f8cb6a9dcf0fd4506a856fbb4a0622b92042978c601a23c840c28f621a59f"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
 dependencies = [
  "basic-toml",
  "bitfield",
@@ -492,14 +587,13 @@ dependencies = [
  "embassy-usb-driver",
  "embassy-usb-synopsys-otg",
  "embedded-can",
- "embedded-dma",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-nb",
  "embedded-io",
  "embedded-io-async",
  "enumset",
- "esp-build",
+ "esp-build 0.1.0 (git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f)",
  "esp-hal-procmacros",
  "esp-metadata",
  "esp-riscv-rt",
@@ -525,8 +619,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-embassy"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5206e4c63993df6da47fd30432ccc22111bd084ebfd0372afd45202b491e717e"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -534,17 +627,18 @@ dependencies = [
  "document-features",
  "embassy-executor",
  "embassy-time-driver",
- "esp-build",
+ "esp-build 0.1.0 (git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f)",
  "esp-hal",
+ "esp-hal-procmacros",
  "esp-metadata",
  "portable-atomic",
+ "static_cell",
 ]
 
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9569ccb286c5a0c39292dbaaa0995bbb2a2a9d671ef3ce807b8b5b3d9a589d35"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
 dependencies = [
  "darling",
  "document-features",
@@ -559,10 +653,11 @@ dependencies = [
 [[package]]
 name = "esp-metadata"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6013420eb303c3087d82c2d2a38944427662b0b07a9ae79e5b1636fc1442e0ba"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
 dependencies = [
+ "anyhow",
  "basic-toml",
+ "clap",
  "lazy_static",
  "serde",
  "strum 0.26.3",
@@ -584,14 +679,13 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58cd4fa834980ba64aad00a5c2c1a630020af984eadef65a125cb99085f6f54c"
 dependencies = [
- "esp-build",
+ "esp-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "esp-riscv-rt"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc32298ed7c263b06c8b031704d8517cc62c819f2a9d5c261d0cb119634d6e9"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0e333f7aa2d36be97f5e42e427615e5e9dd629f#0e333f7aa2d36be97f5e42e427615e5e9dd629f6"
 dependencies = [
  "document-features",
  "riscv",
@@ -601,8 +695,7 @@ dependencies = [
 [[package]]
 name = "esp32"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4f67907f683a5049ad257cb57a757852bce959eed3e0e8f5e8c212de807714"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
 dependencies = [
  "critical-section",
  "defmt",
@@ -613,8 +706,7 @@ dependencies = [
 [[package]]
 name = "esp32c2"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716899095bd30d98a705257470e47383d2e19acece0a14fe0884da029668e4a7"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
 dependencies = [
  "critical-section",
  "defmt",
@@ -624,8 +716,7 @@ dependencies = [
 [[package]]
 name = "esp32c3"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6865f32b4936b2c396fd1bed3e935850b130282fdcb935af79c2da192cb638"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
 dependencies = [
  "critical-section",
  "defmt",
@@ -635,8 +726,7 @@ dependencies = [
 [[package]]
 name = "esp32c6"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5824acf92f8536c997e673113ce704c004f77e154fd550dc511b92d61bb34f6"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
 dependencies = [
  "critical-section",
  "defmt",
@@ -646,8 +736,7 @@ dependencies = [
 [[package]]
 name = "esp32h2"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99592d177fda6a7756d6e98822b0c30edad8ac55342303beec72f6c073dca4fa"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
 dependencies = [
  "critical-section",
  "defmt",
@@ -657,8 +746,7 @@ dependencies = [
 [[package]]
 name = "esp32s2"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3037b677df9ca5e58b278cdf9a68206fd993a5363d5d1f3e067132f75c6a919"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
 dependencies = [
  "critical-section",
  "defmt",
@@ -669,8 +757,7 @@ dependencies = [
 [[package]]
 name = "esp32s3"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7989c8d8e81a0b1037926ccaec6b2ff8bed36b758e6beb9145111ba33892fe6f"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=bf5890e#bf5890eabc56f1c894f0201ec7d28e0b441b4d26"
 dependencies = [
  "critical-section",
  "defmt",
@@ -812,6 +899,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "lazy_static"
@@ -1277,6 +1370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,7 +1399,16 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,46 +781,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
@@ -835,7 +799,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
- "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -1057,9 +1020,6 @@ dependencies = [
  "esp-hal",
  "esp-hal-embassy",
  "esp-println 0.9.1",
- "futures",
- "static_cell",
- "strum 0.26.3",
 ]
 
 [[package]]

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(test), no_std)]
-#![feature(lint_reasons)]
 #![allow(
     incomplete_features,
     reason = "Drivers use constant generics to calculate the needed buffer sizes"

--- a/photogate/Cargo.toml
+++ b/photogate/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-executor = { version = "0.5.0", features = ["defmt", "nightly", "integrated-timers"] }
+embassy-executor = { version = "0.6.0", features = ["defmt", "nightly", "integrated-timers"] }
 embassy-sync = { version = "0.6.0", features = ["defmt"] }
 embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
 embedded-hal-async = "1.0.0"
@@ -17,8 +17,8 @@ esp-backtrace = { version = "0.13.0", features = [
     "panic-handler",
     "defmt",
 ] }
-esp-hal = { version = "0.19.0", features = ["esp32c3", "async", "defmt"] }
-esp-hal-embassy = { version = "0.2.0", features = ["esp32c3", "executors", "integrated-timers", "defmt"] }
+esp-hal = { version = "0.19.0", git = "https://github.com/esp-rs/esp-hal.git", rev = "0e333f7aa2d36be97f5e42e427615e5e9dd629f", features = ["esp32c3", "async", "defmt"] }
+esp-hal-embassy = { version = "0.2.0", git = "https://github.com/esp-rs/esp-hal.git", rev = "0e333f7aa2d36be97f5e42e427615e5e9dd629f", features = ["esp32c3", "executors", "integrated-timers", "defmt"] }
 esp-println = { version = "0.9.0", features = ["esp32c3", "defmt-espflash"] }
 futures = { version = "0.3.30", default-features = false }
 strum = { version = "0.26.2", features = ["derive"], default-features = false }

--- a/photogate/Cargo.toml
+++ b/photogate/Cargo.toml
@@ -25,6 +25,7 @@ strum = { version = "0.26.2", features = ["derive"], default-features = false }
 drivers = { path = "../drivers" }
 defmt = "0.3.8"
 static_cell = { version = "2.1.0", features = ["nightly"] }
+critical-section = "1.1.3"
 
 [[bin]]
 name = "photogate-node"

--- a/photogate/Cargo.toml
+++ b/photogate/Cargo.toml
@@ -20,11 +20,8 @@ esp-backtrace = { version = "0.13.0", features = [
 esp-hal = { version = "0.19.0", git = "https://github.com/esp-rs/esp-hal.git", rev = "0e333f7aa2d36be97f5e42e427615e5e9dd629f", features = ["esp32c3", "async", "defmt"] }
 esp-hal-embassy = { version = "0.2.0", git = "https://github.com/esp-rs/esp-hal.git", rev = "0e333f7aa2d36be97f5e42e427615e5e9dd629f", features = ["esp32c3", "executors", "integrated-timers", "defmt"] }
 esp-println = { version = "0.9.0", features = ["esp32c3", "defmt-espflash"] }
-futures = { version = "0.3.30", default-features = false }
-strum = { version = "0.26.2", features = ["derive"], default-features = false }
 drivers = { path = "../drivers" }
 defmt = "0.3.8"
-static_cell = { version = "2.1.0", features = ["nightly"] }
 critical-section = "1.1.3"
 
 [[bin]]

--- a/photogate/Cargo.toml
+++ b/photogate/Cargo.toml
@@ -11,15 +11,15 @@ embassy-sync = { version = "0.6.0", features = ["defmt"] }
 embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
 embedded-hal-async = "1.0.0"
 esp-alloc = "0.4.0"
-esp-backtrace = { version = "0.13.0", features = [
+esp-backtrace = { version = "0.14.0", features = [
     "esp32c3",
     "exception-handler",
     "panic-handler",
     "defmt",
 ] }
-esp-hal = { version = "0.19.0", git = "https://github.com/esp-rs/esp-hal.git", rev = "0e333f7aa2d36be97f5e42e427615e5e9dd629f", features = ["esp32c3", "async", "defmt"] }
-esp-hal-embassy = { version = "0.2.0", git = "https://github.com/esp-rs/esp-hal.git", rev = "0e333f7aa2d36be97f5e42e427615e5e9dd629f", features = ["esp32c3", "executors", "integrated-timers", "defmt"] }
-esp-println = { version = "0.9.0", features = ["esp32c3", "defmt-espflash"] }
+esp-hal = { version = "0.20.1", features = ["esp32c3", "async", "defmt"] }
+esp-hal-embassy = { version = "0.3.0", features = ["esp32c3", "executors", "integrated-timers", "defmt"] }
+esp-println = { version = "0.11.0", features = ["esp32c3", "defmt-espflash"] }
 drivers = { path = "../drivers" }
 defmt = "0.3.8"
 critical-section = "1.1.3"

--- a/photogate/rust-toolchain.toml
+++ b/photogate/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-06-12"
+channel = "nightly"
 components = ["rust-src"]
 targets = ["riscv32imc-unknown-none-elf"]

--- a/photogate/src/main.rs
+++ b/photogate/src/main.rs
@@ -112,6 +112,7 @@ static BUTTON: CSMutex<RefCell<Option<ButtonPin>>> = CSMutex::new(RefCell::new(N
 
 #[handler]
 fn handle_gpio() {
+    debug!("GPIO interrupt");
     if let Some(new_button_state) = critical_section::with(|cs| {
         let interrupt_fired = BUTTON.borrow_ref(cs).as_ref().unwrap().is_interrupt_set();
         let state = BUTTON.borrow_ref(cs).as_ref().unwrap().get_level();
@@ -130,6 +131,7 @@ fn handle_gpio() {
         // the amount of time we spend in the interrupt handler. We cannot use yield since
         // interrupts are synchronous and we cannot block as that would freeze the entire program.
         // Hence, we opt for a synchronous, non-blocking approach.
+        debug!("button interrupt");
         let now = Instant::now();
         match INPUT_CHANNEL
             .immediate_publisher()

--- a/photogate/src/main.rs
+++ b/photogate/src/main.rs
@@ -131,12 +131,17 @@ fn handle_gpio() {
         // interrupts are synchronous and we cannot block as that would freeze the entire program.
         // Hence, we opt for a synchronous, non-blocking approach.
         let now = Instant::now();
-        INPUT_CHANNEL
+        match INPUT_CHANNEL
             .immediate_publisher()
-            .publish_immediate(ButtonLevel {
+            .try_publish(ButtonLevel {
                 ts: now,
                 level: new_button_state,
-            });
+            }) {
+            Ok(_) => {}
+            Err(_) => {
+                warn!("Button: Input PubSub is full.")
+            }
+        }
     }
 }
 

--- a/photogate/src/main.rs
+++ b/photogate/src/main.rs
@@ -8,11 +8,10 @@ extern crate alloc;
 use core::{
     cell::RefCell,
     ops::{Deref, DerefMut},
-    pin::pin,
 };
 
 use critical_section::Mutex as CSMutex;
-use defmt::{debug, error, info, warn};
+use defmt::{debug, info, warn};
 use drivers::{
     display::ht16k33_7seg_display::{AsyncI2C7SegDisplay, H16K33Blinkrate},
     initalization::Initialized,
@@ -36,25 +35,24 @@ use esp_hal::{
     Async,
 };
 use esp_println as _;
-use futures::future::{select, Either};
-use strum::EnumCount;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumCount)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FSMStates {
-    Idle = 0,
+    Idle,
     Prepare,
     Ready,
-    TimerRunning,
-    TimerEnd,
+    TimerStart { start: Instant },
+    TimerRunning { start: Instant },
+    TimerEnd { start: Instant, end: Instant },
 }
 
 #[allow(dead_code)]
 type LaserPin = Output<'static, Gpio4>;
 type ButtonPin = Input<'static, Gpio9>;
 type PhotodiodePin = Input<'static, Gpio0>;
-type Photodiode = Mutex<CriticalSectionRawMutex, Option<PhotodiodePin>>;
+type Photodiode = CSMutex<RefCell<Option<PhotodiodePin>>>;
 
-static PHOTODIODE_INPUT: Photodiode = Mutex::new(None);
+static PHOTODIODE_INPUT: Photodiode = CSMutex::new(RefCell::new(None));
 
 const DISPLAY_LENGTH: usize = 4;
 
@@ -67,29 +65,34 @@ static DISPLAY_COMMAND: Signal<CriticalSectionRawMutex, DisplayCommand> = Signal
 const INPUT_CHANNEL_BUFFER_SIZE: usize = 64;
 static INPUT_CHANNEL: PubSubChannel<
     CriticalSectionRawMutex,
-    ButtonLevel,
+    InputType,
     INPUT_CHANNEL_BUFFER_SIZE,
     1,
     1,
 > = PubSubChannel::new();
-static TIMER_SIGNAL: Signal<CriticalSectionRawMutex, TimerSignal> = Signal::new();
 static CANCEL_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
 
 static PHOTOGATE_READY: Signal<CriticalSectionRawMutex, ()> = Signal::new();
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ButtonLevel {
+enum InputType {
+    Button(InputLevel),
+    Photodiode(InputLevel),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InputLevel {
     ts: Instant,
     level: Level,
 }
 
-impl Ord for ButtonLevel {
+impl Ord for InputLevel {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.ts.cmp(&other.ts)
     }
 }
 
-impl PartialOrd for ButtonLevel {
+impl PartialOrd for InputLevel {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
@@ -113,94 +116,56 @@ static BUTTON: CSMutex<RefCell<Option<ButtonPin>>> = CSMutex::new(RefCell::new(N
 #[handler]
 fn handle_gpio() {
     debug!("GPIO interrupt");
+    let now = Instant::now();
+    // NOTE: This current implementation will override presses if the PubSub fills up. If there
+    // is no more space to put another `InputLevel` into the PubSub, the earliest item in the
+    // channel (that has not been read by everyone yet) will be removed.
+    //
+    // The reason why we are opting for a eventually-consistent high availabilty is to minimize
+    // the amount of time we spend in the interrupt handler. We cannot use yield since
+    // interrupts are synchronous and we cannot block as that would freeze the entire program.
+    // Hence, we opt for a synchronous, non-blocking approach.
     if let Some(new_button_state) = critical_section::with(|cs| {
-        let interrupt_fired = BUTTON.borrow_ref(cs).as_ref().unwrap().is_interrupt_set();
-        let state = BUTTON.borrow_ref(cs).as_ref().unwrap().get_level();
-        BUTTON
-            .borrow_ref_mut(cs)
-            .as_mut()
-            .unwrap()
-            .clear_interrupt();
+        let mut button = BUTTON.borrow_ref_mut(cs);
+        let button = button.as_mut().unwrap();
+        let interrupt_fired = button.is_interrupt_set();
+        let state = button.get_level();
+        button.clear_interrupt();
         interrupt_fired.then_some(state)
     }) {
-        // NOTE: This current implementation will override presses if the PubSub fills up. If there
-        // is no more space to put another `ButtonLevel` into the PubSub, the earliest item in the
-        // channel (that has not been read by everyone yet) will be removed.
-        //
-        // The reason why we are opting for a eventually-consistent high availabilty is to minimize
-        // the amount of time we spend in the interrupt handler. We cannot use yield since
-        // interrupts are synchronous and we cannot block as that would freeze the entire program.
-        // Hence, we opt for a synchronous, non-blocking approach.
         debug!("button interrupt");
-        let now = Instant::now();
         match INPUT_CHANNEL
             .immediate_publisher()
-            .try_publish(ButtonLevel {
+            .try_publish(InputType::Button(InputLevel {
                 ts: now,
                 level: new_button_state,
-            }) {
+            })) {
             Ok(_) => {}
             Err(_) => {
-                warn!("Button: Input PubSub is full.")
+                warn!("Button: Input PubSub is full.");
             }
         }
     }
-}
-
-enum TimerSignal {
-    StartTimer(Instant),
-    EndTimer(Instant, Instant),
-}
-#[embassy_executor::task]
-async fn handle_photodiode(
-    photodiode: &'static Photodiode,
-    signal_timer: &'static Signal<CriticalSectionRawMutex, TimerSignal>,
-    cancel: &'static Signal<CriticalSectionRawMutex, ()>,
-) {
-    let starttime = {
-        let mut lock = photodiode.lock().await;
-        let photodiode = lock.as_mut().unwrap();
-        #[allow(clippy::let_and_return)]
-        let start = match select(pin!(photodiode.wait_for_high()), cancel.wait()).await {
-            Either::Left((_, _)) => {
-                let start = Instant::now();
-                signal_timer.signal(TimerSignal::StartTimer(start));
-                debug!("Start signaled: {}", start);
-                start
+    if let Some(new_photodiode_state) = critical_section::with(|cs| {
+        let mut photodiode = PHOTODIODE_INPUT.borrow_ref_mut(cs);
+        let photodiode = photodiode.as_mut().unwrap();
+        let interrupt_fired = photodiode.is_interrupt_set();
+        let state = photodiode.get_level();
+        photodiode.clear_interrupt();
+        interrupt_fired.then_some(state)
+    }) {
+        debug!("photodiode interrupt");
+        match INPUT_CHANNEL
+            .immediate_publisher()
+            .try_publish(InputType::Photodiode(InputLevel {
+                ts: now,
+                level: new_photodiode_state,
+            })) {
+            Ok(_) => {}
+            Err(_) => {
+                warn!("Diode: Input PubSub is full.");
             }
-            Either::Right((_, _)) => {
-                cancel.reset();
-                return;
-            }
-        };
-        start
-    };
-    {
-        let mut lock = photodiode.lock().await;
-        let photodiode = lock.as_mut().unwrap();
-        debug!("Waiting for laser beam to reconnect ...");
-        match select(pin!(photodiode.wait_for_low()), cancel.wait()).await {
-            Either::Left((_, _)) => {}
-            Either::Right((_, _)) => {
-                cancel.reset();
-                return;
-            }
-        };
-    }
-    {
-        let mut lock = photodiode.lock().await;
-        let photodiode = lock.as_mut().unwrap();
-        debug!("Waiting for laser beam to break ...");
-        match select(pin!(photodiode.wait_for_high()), cancel.wait()).await {
-            Either::Left((_, _)) => {
-                let endtime = Instant::now();
-                signal_timer.signal(TimerSignal::EndTimer(starttime, endtime));
-                debug!("Stop signaled: {}", endtime);
-            }
-            Either::Right((_, _)) => {
-                cancel.reset();
-            }
-        };
+        }
     }
 }
 
@@ -304,35 +269,6 @@ async fn handle_segment_display(
     }
 }
 
-#[embassy_executor::task]
-async fn check_laser_is_aligned(
-    photodiode: &'static Photodiode,
-    is_ready: &'static Signal<CriticalSectionRawMutex, ()>,
-) {
-    const HOLD_TIME_MSECS: u64 = 3000;
-    let mut ticker = Ticker::every(Duration::from_millis(100));
-    loop {
-        let mut lock = photodiode.lock().await;
-        let photodiode = lock.as_mut().unwrap();
-        match select(
-            Timer::after_millis(HOLD_TIME_MSECS),
-            pin!(photodiode.wait_for_high()),
-        )
-        .await
-        {
-            Either::Left((_, _)) => {
-                is_ready.signal(());
-                return;
-            }
-            Either::Right((_, _)) => {
-                info!("Beam was broken prematurely");
-                ticker.next().await;
-                ticker.reset();
-            }
-        };
-    }
-}
-
 #[esp_hal_embassy::main]
 async fn main(spawner: Spawner) -> ! {
     heap_allocator!(32_168);
@@ -342,8 +278,11 @@ async fn main(spawner: Spawner) -> ! {
 
     let mut io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
     io.set_interrupt_handler(handle_gpio);
-    let photodiode = Input::new(io.pins.gpio0, Pull::Down);
-    PHOTODIODE_INPUT.lock().await.replace(photodiode);
+    let mut photodiode = Input::new(io.pins.gpio0, Pull::Down);
+    critical_section::with(|cs| {
+        photodiode.listen(Event::AnyEdge);
+        PHOTODIODE_INPUT.replace(cs, Some(photodiode));
+    });
     let mut button = Input::new(io.pins.gpio9, Pull::Up);
     critical_section::with(|cs| {
         button.listen(Event::AnyEdge);
@@ -365,13 +304,24 @@ async fn main(spawner: Spawner) -> ! {
         display.initialize().await.unwrap();
     display.set_brightness(15).await.unwrap();
 
-    let mut start_time = None;
-    let mut end_time = None;
-
     let mut ticker = Ticker::every(Duration::from_millis(1));
 
     let mut button_is_down = false;
+    let mut photodiode_state = critical_section::with(|cs| {
+        (
+            Instant::now(),
+            PHOTODIODE_INPUT
+                .borrow_ref(cs)
+                .as_ref()
+                .unwrap()
+                .get_level(),
+        )
+    });
+    if photodiode_state.1 == Level::Low {
+        warn!("Photodiode is already high without the laser on. Is the diode exposed to light?");
+    }
     let mut input_sub = INPUT_CHANNEL.subscriber().unwrap();
+    let mut last_console_print = Instant::now();
 
     let systimer = systimer::SystemTimer::new(peripherals.SYSTIMER).split::<systimer::Target>();
     esp_hal_embassy::init(&clocks, systimer.alarm0);
@@ -394,12 +344,17 @@ async fn main(spawner: Spawner) -> ! {
             // The button was pressed, but the final value of button_is_down will be false
             // However, we would want to move to the Prepare state due to the press
             // Same thing *can* happen with the photodiode (rare but not infeasible)
-            match input.level {
-                Level::High => {
-                    button_is_down = false;
-                }
-                Level::Low => {
-                    button_is_down = true;
+            match input {
+                InputType::Button(input) => match input.level {
+                    Level::High => {
+                        button_is_down = false;
+                    }
+                    Level::Low => {
+                        button_is_down = true;
+                    }
+                },
+                InputType::Photodiode(input) => {
+                    photodiode_state = (input.ts, input.level);
                 }
             }
         }
@@ -412,90 +367,107 @@ async fn main(spawner: Spawner) -> ! {
                 if button_is_down {
                     // If press, go to Prepare
                     PHOTOGATE_READY.reset();
+                    if critical_section::with(|cs| {
+                        PHOTODIODE_INPUT.borrow_ref(cs).as_ref().unwrap().is_low()
+                    }) {
+                        warn!("Photodiode is already high without the laser on. Is the diode exposed to light?");
+                    }
                     // FIXME: Current implementation with button interrupt code and pubsub channel
                     // processing can cause a backlog of responses in the pubsub queue which
                     // affectively DoS the device
-                    match spawner.spawn(check_laser_is_aligned(&PHOTODIODE_INPUT, &PHOTOGATE_READY))
-                    {
-                        Ok(_) => {
-                            *(STATE.lock().await.deref_mut()) = FSMStates::Prepare;
-                            DISPLAY_COMMAND.signal(DisplayCommand::Pending);
-                            info!("Preparing photogate for timing ...");
-                            info!("Hold still ...");
-                        }
-                        Err(e) => error!(
-                            "Error occurred when trying to spawn photodiode preparation task {:?}",
-                            e
-                        ),
-                    }
+                    *(STATE.lock().await.deref_mut()) = FSMStates::Prepare;
+                    DISPLAY_COMMAND.signal(DisplayCommand::Pending);
+                    info!("Preparing photogate for timing ...");
+                    info!("Hold still ...");
+                    photodiode_state.0 = Instant::now();
+                    photodiode_state.1 = Level::High;
                 }
             }
             FSMStates::Prepare => {
                 // Wait for laser to be aligned correctly
                 // Photogate signal should remain low for extended period of time
                 // Move to Ready once complete
+                const CALIBRATION_TIME: Duration = Duration::from_secs(3);
+                const PRINT_DELAY: Duration = Duration::from_millis(500);
                 laser.set_high();
-                if PHOTOGATE_READY.signaled() {
-                    TIMER_SIGNAL.reset();
+                if photodiode_state.1 == Level::Low
+                    && photodiode_state.0 + CALIBRATION_TIME <= Instant::now()
+                {
                     CANCEL_SIGNAL.reset();
-                    match spawner.spawn(handle_photodiode(
-                        &PHOTODIODE_INPUT,
-                        &TIMER_SIGNAL,
-                        &CANCEL_SIGNAL,
-                    )) {
-                        Ok(_) => {
-                            *(STATE.lock().await.deref_mut()) = FSMStates::Ready;
-                            PHOTOGATE_READY.reset();
-                            DISPLAY_COMMAND.signal(DisplayCommand::Zero);
-                            info!("Photogate is ready!");
-                        }
-                        Err(e) => error!(
-                            "Error occurred when trying to spawn photodiode task: {:?}",
-                            e
-                        ),
-                    }
+
+                    *(STATE.lock().await.deref_mut()) = FSMStates::Ready;
+                    PHOTOGATE_READY.reset();
+                    DISPLAY_COMMAND.signal(DisplayCommand::Zero);
+                    info!("Photogate is ready!");
+                    continue;
+                }
+                let now = Instant::now();
+                if last_console_print + PRINT_DELAY <= now
+                    && critical_section::with(|cs| {
+                        PHOTODIODE_INPUT.borrow_ref(cs).as_ref().unwrap().is_high()
+                    })
+                {
+                    info!("Beam was broken prematurely");
+                    last_console_print = now;
                 }
             }
-            FSMStates::Ready | FSMStates::TimerRunning => {
+            FSMStates::Ready => {
+                laser.set_high();
+
+                if button_is_down {
+                    CANCEL_SIGNAL.signal(());
+                    *(STATE.lock().await.deref_mut()) = FSMStates::Idle;
+                    continue;
+                }
+                if photodiode_state.1 == Level::High {
+                    info!("Photogate beam was broken. Timer started");
+                    let start = photodiode_state.0;
+                    DISPLAY_COMMAND.signal(DisplayCommand::StartTimer(start));
+                    *(STATE.lock().await.deref_mut()) = FSMStates::TimerStart { start };
+                }
+            }
+            FSMStates::TimerStart { start } => {
+                laser.set_high();
+                if button_is_down {
+                    CANCEL_SIGNAL.signal(());
+                    *(STATE.lock().await.deref_mut()) = FSMStates::Idle;
+                    continue;
+                }
+                if photodiode_state.1 == Level::Low {
+                    *(STATE.lock().await.deref_mut()) = FSMStates::TimerRunning { start };
+                }
+            }
+            FSMStates::TimerRunning { start } => {
                 laser.set_high();
 
                 if button_is_down {
                     CANCEL_SIGNAL.signal(());
                     *(STATE.lock().await.deref_mut()) = FSMStates::Idle;
                 }
-                if let Some(timer_event) = TIMER_SIGNAL.try_take() {
-                    match timer_event {
-                        TimerSignal::StartTimer(start) => {
-                            info!("Photogate beam was broken. Timer started");
-                            DISPLAY_COMMAND.signal(DisplayCommand::StartTimer(start));
-                            *(STATE.lock().await.deref_mut()) = FSMStates::TimerRunning;
-                        }
-                        TimerSignal::EndTimer(start, end) => {
-                            (start_time, end_time) = (Some(start), Some(end));
-                            info!("Photogate beam was broken. Timer ended");
-                            DISPLAY_COMMAND.signal(DisplayCommand::EndTimer { start, end });
-                            *(STATE.lock().await.deref_mut()) = FSMStates::TimerEnd;
-                        }
-                    }
-                }
-            }
-            FSMStates::TimerEnd => {
-                laser.set_low(); // FIX: Keep beam on for ~1-2 seconds to allow for human
-                                 // timing if needed
-
-                // Display time
-                if let (Some(start), Some(end)) = (start_time, end_time) {
+                if photodiode_state.1 == Level::High {
+                    info!("Photogate beam was broken. Timer ended");
+                    let end = photodiode_state.0;
+                    // Display time
+                    DISPLAY_COMMAND.signal(DisplayCommand::EndTimer { start, end });
                     let duration = end.duration_since(start);
                     info!(
                         "Time: {}",
                         (duration.as_micros() as f64) / (SECS_TO_MICROS as f64)
                     );
-                    start_time = None;
-                    end_time = None;
-                } else {
-                    warn!("Time was not able to be calculated!");
+                    *(STATE.lock().await.deref_mut()) = FSMStates::TimerEnd { start, end };
                 }
-                *(STATE.lock().await.deref_mut()) = FSMStates::Idle;
+            }
+            FSMStates::TimerEnd { start: _, end } => {
+                const LASER_ON_DELAY: u64 = 3;
+                if button_is_down {
+                    CANCEL_SIGNAL.signal(());
+                    *(STATE.lock().await.deref_mut()) = FSMStates::Idle;
+                }
+                if end + Duration::from_secs(LASER_ON_DELAY) <= Instant::now() {
+                    // Keep beam on for ~1-2 seconds to allow for human timing if needed
+                    laser.set_low();
+                    *(STATE.lock().await.deref_mut()) = FSMStates::Idle;
+                }
             }
         }
     }


### PR DESCRIPTION
Changes GPIO inputs to be handled by an interrupt handler rather than waiting asynchronously.

Having an interrupt handler has the following benefits:
- Allows for timestamping inputs inside the interrupt handler rather than in user space
  - The interrupt handler records it (essentially) immediately when the input change happens rather than at some unknown point in time in the near future
- It is very unlikely the device will miss an input change
  - Asynchronously waiting for the GPIO future in order for the internal interrupt handler to listen for an input change can result in wrong timings (since the internal interrupt handler does not deal with timestamping)
  - The only time the device can miss an input is if a GPIO pin changes state to cause an interrupt and then changes again before the first interrupt is handled (this time period is incredibly short, typically <100 cycles or roughly 62.5μs on the ESP32-C3 160MHz processor, so it is rather insignificant due to most things with significant mass are not able affect the system that fast)
- Becomes independent from the asynchronous runtime
  - There is no longer a possibility that a long-running async task now starves the input dispatch and timestamping (as was seen before with the display starving the other async tasks (`Ticker` can starve other tasks if it runs behind)) https://github.com/Nydauron/photogate/blob/630f9abafe36d0ce0fb8a5dea19795329227d6ca/src/main.rs#L123-L161